### PR TITLE
Adding database-persistance configuration and interfaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/product/productManager/domain/model/Product.java
+++ b/src/main/java/com/product/productManager/domain/model/Product.java
@@ -1,7 +1,15 @@
 package com.product.productManager.domain.model;
 
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
 public class Product {
-    private Long id;
+    @Id
+    @GeneratedValue(strategy= GenerationType.AUTO)
+    private Integer id;
     private String name;
     private String description;
     private Double weight;
@@ -19,11 +27,11 @@ public class Product {
         this.country = country;
     }
 
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/product/productManager/domain/repository/ProductRepository.java
+++ b/src/main/java/com/product/productManager/domain/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.product.productManager.domain.repository;
+
+import com.product.productManager.domain.model.Product;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ProductRepository extends CrudRepository<Product,Integer> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
+spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/db_example
+spring.datasource.username=springuser
+spring.datasource.password=ThePassword
+spring.datasource.driver-class-name =com.mysql.cj.jdbc.Driver
+#spring.jpa.show-sql: true


### PR DESCRIPTION
Spring context still not starting since database comm is failing (due to lack of database)

# Whats new
- Changing product id type to Integer. Long is too much for this. Maybe in real world.
- Adding database configuration in application.properties file
- Creating repository interface for product
- Adding MySQL connector dependency